### PR TITLE
fix: clearing cell removes hyperlink

### DIFF
--- a/src/controllers/controlHistory.js
+++ b/src/controllers/controlHistory.js
@@ -83,7 +83,8 @@ const controlHistory = {
                 "RowlChange": ctr.RowlChange,
                 "cdformat": ctr.cdformat,
                 "dataVerification": ctr.dataVerification,
-                "dynamicArray": ctr.dynamicArray
+                "dynamicArray": ctr.dynamicArray,
+                "hyperlink": ctr.hyperlink,
             }
            // jfrefreshgrid(ctr.data, ctr.range, allParam);
 
@@ -459,7 +460,8 @@ const controlHistory = {
                 "RowlChange": ctr.RowlChange,
                 "cdformat": ctr.curCdformat,
                 "dataVerification": ctr.curDataVerification,
-                "dynamicArray": ctr.curDynamicArray
+                "dynamicArray": ctr.curDynamicArray,
+                "hyperlink": ctr.curHyperlink,
             }
 
             formulaHistoryHanddler(ctr, "undo");

--- a/src/controllers/rowColumnOperation.js
+++ b/src/controllers/rowColumnOperation.js
@@ -2068,7 +2068,10 @@ export function rowColumnOperationInitial(){
 
                 return;
             }
-            const hyperlinkMap = Store.luckysheetfile[getSheetIndex(Store.currentSheetIndex)].hyperlink;
+
+            const file = Store.luckysheetfile[getSheetIndex(Store.currentSheetIndex)];
+            const hyperlink = file.hyperlink && $.extend(true, {}, file.hyperlink);
+            let hyperlinkUpdated;
 
             for(let s = 0; s < Store.luckysheet_select_save.length; s++){
                 let r1 = Store.luckysheet_select_save[s].row[0], 
@@ -2101,14 +2104,15 @@ export function rowColumnOperationInitial(){
                             d[r][c] = null;
                         }
                         // 同步清除 hyperlink
-                        if (hyperlinkMap && hyperlinkMap[`${r}_${c}`]) {
-                            delete hyperlinkMap[`${r}_${c}`];
+                        if (hyperlink?.[`${r}_${c}`]) {
+                            delete hyperlink[`${r}_${c}`];
+                            hyperlinkUpdated = true;
                         }
                     }
                 }
             }
 
-            jfrefreshgrid(d, Store.luckysheet_select_save);
+            jfrefreshgrid(d, Store.luckysheet_select_save, hyperlinkUpdated && { hyperlink });
 
             // 清空编辑框的内容
             // 备注：在functionInputHanddler方法中会把该标签的内容拷贝到 #luckysheet-functionbox-cell

--- a/src/global/refresh.js
+++ b/src/global/refresh.js
@@ -58,6 +58,7 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
     let cdformat = allParam["cdformat"];  //条件格式
     let dataVerification = allParam["dataVerification"];  //数据验证
     let dynamicArray = allParam["dynamicArray"];  //动态数组
+    let hyperlink = allParam["hyperlink"];
 
     let file = Store.luckysheetfile[getSheetIndex(Store.currentSheetIndex)];
 
@@ -110,6 +111,8 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
             "curDataVerification": curDataVerification,
             "dynamicArray": $.extend(true, [], file["dynamicArray"]),
             "curDynamicArray": curDynamicArray,
+            "hyperlink": hyperlink && $.extend(true, {}, file.hyperlink),
+            "curHyperlink": hyperlink,
             "range": range,
             "dataRange": [...file.luckysheet_select_save]// 保留操作时的选区
         });
@@ -151,6 +154,12 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
         file["dynamicArray"] = dynamicArray;
 
         server.saveParam("all", Store.currentSheetIndex, dynamicArray, { "k": "dynamicArray" });
+    }
+
+    if(hyperlink != null){
+        file["hyperlink"] = hyperlink;
+        hyperlinkCtrl.hyperlink = hyperlink;
+        server.saveParam("all", Store.currentSheetIndex, hyperlink, { "k": "hyperlink" });
     }
 
     //更新数据的范围


### PR DESCRIPTION
Currently, when a cell is cleared, the hyperlink remains.
There is no way to remove the hyperlink on UI.
This PR fixes that clearing cell removes the hyperlink.