### PR TITLE
fix offsetting of entire row/column formula like "A1:B"

### DIFF
--- a/src/global/formula.js
+++ b/src/global/formula.js
@@ -2101,15 +2101,11 @@ const luckysheetformula = {
                 return _this.error.r;
             }
 
-            if (isNaN(col[0]) && isNaN(col[1])) {
-                return prefix + $row0 + (row[0]) + ":" + $row1 + (row[1]);
-            }
-            else if (isNaN(row[0]) && isNaN(row[1])) {
-                return prefix + $col0 + chatatABC(col[0]) + ":" + $col1 + chatatABC(col[1]);
-            }
-            else {
-                return prefix + $col0 + chatatABC(col[0]) + $row0 + (row[0]) + ":" + $col1 + chatatABC(col[1]) + $row1 + (row[1]);
-            }
+            const col0 = isNaN(col[0]) ? "" : $col0 + chatatABC(col[0]);
+            const col1 = isNaN(col[1]) ? "" : $col1 + chatatABC(col[1]);
+            const row0 = isNaN(row[0]) ? "" : $row0 + row[0];
+            const row1 = isNaN(row[1]) ? "" : $row1 + row[1];
+            return prefix + col0 + row0 + ":" + col1 + row1;
         }
     },
     downparam: function (txt, step) {

--- a/src/global/formula.js
+++ b/src/global/formula.js
@@ -2019,7 +2019,7 @@ const luckysheetformula = {
                 row += step;
             }
 
-            if (row[0] < 0 || col[0] < 0) {
+            if (row < 0 || col < 0) {
                 return _this.error.r;
             }
 


### PR DESCRIPTION
Currently, the offset of formula `=SUM(A1:B)` produces `=SUM(A2:BNaN)`.
This PR fixes it to produce `=SUM(A2:B)`.

Also, currently, copying B1 having `=A1` to A2 produces `=2`.
This PR fixes it to produces `=#REF!` as in Excel.