### PR TITLE
fix: update calcChain and hyperlink on merge cells

### DIFF
--- a/src/controllers/controlHistory.js
+++ b/src/controllers/controlHistory.js
@@ -344,6 +344,8 @@ const controlHistory = {
         else if (ctr.type == "mergeChange") {
             let allParam = {
                 "cfg": ctr.config,
+                calc: ctr.calc,
+                hyperlink: ctr.hyperlink,
             }
 
             jfrefreshgrid(ctr.data, ctr.range, allParam);
@@ -667,6 +669,8 @@ const controlHistory = {
         else if (ctr.type == "mergeChange") {
             let allParam = {
                 "cfg": ctr.curConfig,
+                calc: ctr.curCalc,
+                hyperlink: ctr.curHyperlink,
             }
 
             jfrefreshgrid(ctr.curData, ctr.range, allParam);

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -3418,6 +3418,15 @@ const menuButton = {
             }
         }
 
+        const file = Store.luckysheetfile[getSheetIndex(Store.currentSheetIndex)];
+        const calc = file.calcChain?.filter(({ r, c }) => d[r][c]?.f);
+        const hyperlink = file.hyperlink && Object.fromEntries(
+            Object.entries(file.hyperlink).filter(([r_c]) => {
+                const [r, c] = r_c.split('_');
+                return d[r][c]?.v;
+            })
+        );
+
         if (Store.clearjfundo) {
             Store.jfundo.length  = 0;
             Store.jfredo.push({
@@ -3427,12 +3436,16 @@ const menuButton = {
                 "curData": d,
                 "range": $.extend(true, [], Store.luckysheet_select_save),
                 "config": $.extend(true, {}, Store.config),
-                "curConfig": cfg
+                "curConfig": cfg,
+                "calc": file.calcChain,
+                "curCalc": calc,
+                "hyperlink": file.hyperlink,
+                "curHyperlink": hyperlink,
             });
         }
 
         Store.clearjfundo = false;
-        jfrefreshgrid(d, Store.luckysheet_select_save, {"cfg": cfg});
+        jfrefreshgrid(d, Store.luckysheet_select_save, {cfg, calc, hyperlink});
         Store.clearjfundo = true;
     },
     borderfix: function(d, r, c){

--- a/src/global/refresh.js
+++ b/src/global/refresh.js
@@ -54,6 +54,7 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
     }
 
     let cfg = allParam["cfg"];  //config
+    let calc = allParam["calc"];
     let RowlChange = allParam["RowlChange"];  //行高改变
     let cdformat = allParam["cdformat"];  //条件格式
     let dataVerification = allParam["dataVerification"];  //数据验证
@@ -104,6 +105,8 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
             "sheetIndex": Store.currentSheetIndex, 
             "config": $.extend(true, {}, Store.config), 
             "curConfig": curConfig,
+            "calc": $.extend(true, [], file.calcChain),
+            "curCalc": calc,
             "cdformat":  $.extend(true, [], file["luckysheet_conditionformat_save"]),
             "curCdformat": curCdformat,
             "RowlChange": RowlChange,
@@ -133,6 +136,11 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
         if(RowlChange != null){
             jfrefreshgrid_rhcw(Store.flowdata.length, Store.flowdata[0].length);
         }
+    }
+
+    if(calc != null){
+        file.calcChain = calc;
+        server.saveParam("all", Store.currentSheetIndex, calc, { "k": "calcChain" });
     }
 
     //condition format, null or empty array are not processed


### PR DESCRIPTION
Currently, merging cells clears the values and formulas in the merged cells, but does not update the `calcChain` and `hyperlink`.
This PR fixed it.