### PR TITLE
fix: copying B1 having "=A1" to A2 generates "#REF!" instead of "=2"

### DIFF
--- a/src/global/formula.js
+++ b/src/global/formula.js
@@ -2019,7 +2019,7 @@ const luckysheetformula = {
                 row += step;
             }
 
-            if (row[0] < 0 || col[0] < 0) {
+            if (row < 0 || col < 0) {
                 return _this.error.r;
             }
 


### PR DESCRIPTION
Currently, copying the `B1` cell having the formula `=A1` to the `A2` cell produces the formula `=2`.
This PR fixes it to produces `=#REF!` as in Excel.