### PR TITLE
增加在 Cloud IDE 中在线阅读代码和预览示例的入口

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -20,6 +20,10 @@
 
 ![演示](/docs/.vuepress/public/img/LuckysheetDemo.gif)
 
+## 在 Cloud IDE 中预览
+
+[https://idegithub.com/dream-num/Luckysheet](https://idegithub.com/dream-num/Luckysheet)
+
 ## 插件
 - [Luckyexcel](https://gitee.com/mengshukeji/Luckyexcel)：excel导入导出库 
 - [chartMix](https://gitee.com/mengshukeji/chartMix)：图表插件

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ English| [简体中文](./README-zh.md)
 
 ![Demo](/docs/.vuepress/public/img/LuckysheetDemo.gif)
 
+## Start On Cloud IDE
+
+[https://idegithub.com/dream-num/Luckysheet](https://idegithub.com/dream-num/Luckysheet)
+
 ## Plugins
 - [Luckyexcel](https://github.com/mengshukeji/Luckyexcel): Excel import and export library
 - [chartMix](https://github.com/mengshukeji/chartMix): Chart plugin

--- a/preview.yml
+++ b/preview.yml
@@ -1,0 +1,10 @@
+# preview.yml
+autoOpen: true # 打开工作空间时是否自动开启所有应用的预览
+apps:
+  - port: 3000 # 应用的端口
+    run: npm i --registry=https://registry.npmmirror.com && npm run dev # 应用的启动命令
+    command: # 使用此命令启动服务，且不执行run
+    root: ./ # 应用的启动目录
+    name: luckysheet # 应用名称
+    description: Luckysheet is an online spreadsheet like excel that is powerful, simple to configure, and completely open source. # 应用描述
+    autoOpen: true # 打开工作空间时是否自动开启预览（优先级高于根级 autoOpen)


### PR DESCRIPTION
这边写了个脚本，可以直接在云 IDE 中阅读 Luckysheet 代码并自动启动预览，可以直接修改示例调试，非常方便。