### PR TITLE
feat: 修复指定order下标为0（第一个sheet）

### DIFF
--- a/src/global/extend.js
+++ b/src/global/extend.js
@@ -21,7 +21,7 @@ import Store from '../store';
  * @returns 
  */
 function luckysheetextendtable(type, index, value, direction, sheetIndex) {
-    sheetIndex = sheetIndex || Store.currentSheetIndex;
+    sheetIndex = sheetIndex ?? Store.currentSheetIndex;
 
     if(type=='row' && !checkProtectionAuthorityNormal(sheetIndex, "insertRows")){
         return;


### PR DESCRIPTION
当在非第一个sheet中试图在第一个sheet中插入表格项的时候，会出现插入在了当前sheet的bug。
源码中这块的处理没有考虑到idx为0的情况，会将其替换为当前sheet的idx