### PR TITLE
跳过coladd长度为0时非常耗时的循环

### DIFF
--- a/src/global/getdata.js
+++ b/src/global/getdata.js
@@ -211,8 +211,11 @@ export function datagridgrowth(data, addr, addc, iscallback) {
         rowadd.push(null);
     }
 
-    for (let r = 0; r < data.length; r++) {
-        data[r] = [].concat(data[r].concat(coladd));
+    // 下面循环非常耗时, 在coladd为空时是无用循环
+    if (coladd && coladd.length) {
+        for (let r = 0; r < data.length; r++) {
+            data[r] = [].concat(data[r].concat(coladd));
+        }
     }
 
     for (let r = 0; r < addr; r++) {


### PR DESCRIPTION
跳过datagridgrowth函数内coladd为空时执行的 [].concat(coladd), 极大提升加载速度