### PR TITLE
fix(src/controllers/filter.js): 合并单元格筛选异常

### DIFF
--- a/src/controllers/filter.js
+++ b/src/controllers/filter.js
@@ -550,7 +550,13 @@ function initialFilterHandler(){
                 }
                 else{
                     let v, m;
-                    if(cell == null || isRealNull(cell.v)){
+                    if(isRealNull(cell.v) && cell?.mc){
+                        const { r, c } = cell.mc;
+                        const mainCell = Store.flowdata[r][c];
+                        v = mainCell.v;
+                        m = mainCell.m;
+                    }
+                    else if(cell == null || isRealNull(cell.v)){
                         v = null;
                         m = null;
                     }
@@ -1735,7 +1741,12 @@ function initialFilterHandler(){
                 let cell = Store.flowdata[r][cindex];
 
                 let value;
-                if(cell == null || isRealNull(cell.v)){
+                if (isRealNull(cell.v) && cell?.mc) {
+                    const { r, c } = cell.mc
+                    const mainCell = Store.flowdata[r][c]
+                    value = mainCell.v + "#$$$#" + mainCell.m;
+                }
+                else if(cell == null || isRealNull(cell.v)){
                     value = "null#$$$#null";
                 }
                 else if(cell.ct != null && cell.ct.t == "d"){


### PR DESCRIPTION
合并单元格在筛选时只显示了主单元格, 非主单元格归属于空白单元格了

fix #1309 -- https://github.com/dream-num/Luckysheet/issues/1309