### PR TITLE
fix: removed extra text were appeared while selecting a whole column…

### DIFF
--- a/src/global/count.js
+++ b/src/global/count.js
@@ -59,16 +59,16 @@ export function countfunc() {
 
     //处理成亿万格式
     if (isFinite(max) || isFinite(min)) {
-        ret += "<span>"+locale_formula.sum+":" + update("w", sum) + "</span>";
-        ret += "<span>"+locale_formula.average+":" + update("w", Math.round(sum / count * 10000) / 10000) + "</span>";
+        ret += "<span>"+locale_formula.sum+":" + sum + "</span>";
+        ret += "<span>"+locale_formula.average+":" +  Math.round(sum / count * 10000) / 10000 + "</span>";
     }
 
     if (isFinite(max)) {
-        ret += "<span>"+locale_formula.max+":" + update("w", max) + "</span>";
+        ret += "<span>"+locale_formula.max+":" +  max + "</span>";
     }
 
     if (isFinite(min)) {
-        ret += "<span>"+locale_formula.min+":" + update("w", min) + "</span>";
+        ret += "<span>"+locale_formula.min+":" +  min + "</span>";
     }
 
     $("#luckysheet-sta-content").html(ret);


### PR DESCRIPTION
### … issue #1342 reported [more ref](https://github.com/dream-num/Luckysheet/issues/1342#issue-1736061483)

#### once we select a column, at the bottom of the sheet simple calculation not formatted correctly

_check the image( at the bottom of the sheet now showing correct digits)_

![image](https://github.com/dream-num/Luckysheet/assets/71221556/64a0f685-de66-4e58-b0bb-f017d051c66e)
