### PR TITLE
fix: 修复 setCellValue 方法bug 仅当新设置的单元格不含有公式时才能删除原公式链 fixed#1367 

### DIFF
--- a/src/global/api.js
+++ b/src/global/api.js
@@ -199,6 +199,8 @@ export function setCellValue(row, column, value, options = {}) {
             }
             if(value.f!=null){
                 curv.f = value.f;
+            } else {
+                formula.delFunctionGroup(row, column);
             }
             if(value.v!=null){
                 curv.v = value.v;
@@ -209,7 +211,6 @@ export function setCellValue(row, column, value, options = {}) {
             if(value.m!=null){
                 curv.m = value.m;
             }
-            formula.delFunctionGroup(row, column);
             setcellvalue(row, column, data, curv);//update text value
         }
         for(let attr in value){


### PR DESCRIPTION
fixed #1367