### PR TITLE
fix:修复禁用sheet菜单重命名时，仍可双击sheet名称来重命名的问题。

### DIFF
--- a/src/controllers/sheetBar.js
+++ b/src/controllers/sheetBar.js
@@ -248,7 +248,7 @@ export function initialSheetBar(){
     });
 
     let luckysheetsheetnameeditor = function ($t) {
-        if(Store.allowEdit===false){
+        if(Store.allowEdit===false || !luckysheetConfigsetting.sheetRightClickConfig.rename){
             return;
         }
         $t.attr("contenteditable", "true").addClass("luckysheet-mousedown-cancel").data("oldtxt", $t.text());


### PR DESCRIPTION
修复当sheetRightClickConfig的rename为false时，仍然可以通过双击底部sheet名称来进行工作表重命名的问题。