### PR TITLE
fix: 解决有隐藏列时筛选数据错乱的问题

### DIFF
--- a/src/controllers/filter.js
+++ b/src/controllers/filter.js
@@ -241,8 +241,10 @@ function createFilterOptions(luckysheet_filter_save, filterObj) {
     let optionHTML = "";
 
     for (let c = c1; c <= c2; c++) {
+        const isHide = Store.config != null && Store.config["colhidden"] != null && c in Store.config["colhidden"]
+
         if(filterObj == null || filterObj[c - c1] == null){
-            optionHTML += '<div data-rowhidden="" data-str="'+ r1 +'" data-edr="'+ r2 +'" data-cindex="'+ c +'" data-stc="'+ c1 +'" data-edc="'+ c2 +'" class="luckysheet-filter-options" style="left:'+ (Store.visibledatacolumn[c] - 20) +'px;top:'+ row_pre +'px;display:block;"><i class="fa fa-caret-down" aria-hidden="true"></i></div>';
+            optionHTML += '<div data-rowhidden="" data-str="'+ r1 +'" data-edr="'+ r2 +'" data-cindex="'+ c +'" data-stc="'+ c1 +'" data-edc="'+ c2 +'" class="luckysheet-filter-options" style="left:'+ (Store.visibledatacolumn[c] - 20) +'px;top:'+ row_pre +'px;display:'+ (isHide ? 'none' : 'block') +';"><i class="fa fa-caret-down" aria-hidden="true"></i></div>';
         }
         else{
             let caljs_data;
@@ -274,7 +276,7 @@ function createFilterOptions(luckysheet_filter_save, filterObj) {
                 caljs_data = '';
             }
 
-            optionHTML += '<div data-rowhidden="'+ JSON.stringify(filterObj[c - c1].rowhidden).replace(/\"/g, "'") +'" '+ caljs_data +' data-str="'+ r1 +'" data-edr="'+ r2 +'" data-cindex="'+ c +'" data-stc="'+ c1 +'" data-edc="'+ c2 +'" class="luckysheet-filter-options luckysheet-filter-options-active" style="left:'+ (Store.visibledatacolumn[c] - 20) +'px;top:'+ row_pre +'px;display:block;"><i class="fa fa-filter luckysheet-mousedown-cancel" aria-hidden="true"></i></div>';
+            optionHTML += '<div data-rowhidden="'+ JSON.stringify(filterObj[c - c1].rowhidden).replace(/\"/g, "'") +'" '+ caljs_data +' data-str="'+ r1 +'" data-edr="'+ r2 +'" data-cindex="'+ c +'" data-stc="'+ c1 +'" data-edc="'+ c2 +'" class="luckysheet-filter-options luckysheet-filter-options-active" style="left:'+ (Store.visibledatacolumn[c] - 20) +'px;top:'+ row_pre +'px;display:'+ (isHide ? 'none' : 'block') +';"><i class="fa fa-filter luckysheet-mousedown-cancel" aria-hidden="true"></i></div>';
         }
     }
 


### PR DESCRIPTION
问题复现步骤：
1. 将B列隐藏
2. 将A-C列区域数据作为筛选选取
3. 筛选A列或C列数据
4. 选择按值过滤
此时会发现，筛选值列表与实际列数据不符

（原因是，隐藏列后，未隐藏创建的筛选dom标签，导致标签重叠，获取到的是其他下标列的row数据）