### PR TITLE
新增特性，修复bug

### DIFF
--- a/src/controllers/handler.js
+++ b/src/controllers/handler.js
@@ -5516,9 +5516,9 @@ export default function luckysheetHandler() {
         // *如果禁止前台编辑，则中止下一步操作
         if (!checkIsAllowEdit()) {
             tooltip.info("", locale().pivotTable.errorNotAllowEdit);
+            return;
         }
         if (!checkProtectionNotEnable(Store.currentSheetIndex)) {
-            return;
             return;
         }
 

--- a/src/controllers/select.js
+++ b/src/controllers/select.js
@@ -8,7 +8,7 @@ import { getSheetIndex, getRangetxt } from '../methods/get';
 import Store from '../store';
 import method from '../global/method';
 import locale from '../locale/locale';
-import { refreshMenuButtonFocus } from "../global/api";
+import { refreshMenuButtonFocus, getRangesByTxt, checkRangeWithinSpecifiedRange } from "../global/api";
 
 //公式函数 选区实体框
 function seletedHighlistByindex(id, r1, r2, c1, c2) {
@@ -184,6 +184,9 @@ function selectHightlightShow(isRestore = false) {
     
         /* 刷新当前状态栏 */
         refreshMenuButtonFocus();
+
+        // 刷新上方工具栏状态(不在允许输入范围内，工具栏不可用)
+        refreshToolbar()
     }
 
     Store.luckysheetfile[getSheetIndex(Store.currentSheetIndex)].luckysheet_select_save = Store.luckysheet_select_save;
@@ -195,6 +198,27 @@ function selectHightlightShow(isRestore = false) {
         }
         
         Store.luckysheet_select_save_previous = luckysheet_select_save_previous;
+}
+
+// 刷新工具栏
+function refreshToolbar() {
+    if (!Store.config?.authority?.allowRangeList || Store.config?.authority?.allowRangeList?.length === 0) {
+        return
+    }
+    const currentAllowedRange = []
+    Store.config?.authority?.allowRangeList?.forEach((range) => {
+       const allowRange = getRangesByTxt(range.sqref);
+       currentAllowedRange.push(...(allowRange || []))
+    })
+    // 检查修改区域是否是保护区域内 如果是不能修改
+    const hasDisabled = $('#luckysheet-wa-editor').hasClass('disabled')
+    const within = checkRangeWithinSpecifiedRange(Store.luckysheet_select_save, currentAllowedRange);
+    if (!within) {
+        !hasDisabled && $('#luckysheet-wa-editor').addClass('disabled')
+    } else {
+        hasDisabled && $('#luckysheet-wa-editor').removeClass('disabled')
+    }
+
 }
 
 //选区标题栏

--- a/src/css/luckysheet-core.css
+++ b/src/css/luckysheet-core.css
@@ -212,6 +212,15 @@
     transition: all 0.2s;
 }
 
+.luckysheet-wa-editor.disabled>:not(#luckysheet-icon-undo):not(#luckysheet-icon-redo) {
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.6;
+    filter: alpha(opacity=60);
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
 /* 
 .luckysheet-wa-editor>div.luckysheetfulltoolbar {
     display: inline-block;

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -38,7 +38,6 @@ import controlHistory from '../controllers/controlHistory';
 import { zoomRefreshView, zoomNumberDomBind } from '../controllers/zoom';
 import dataVerificationCtrl from "../controllers/dataVerificationCtrl";
 import imageCtrl from '../controllers/imageCtrl';
-import customCtrl from '../controllers/customCtrl';
 import dayjs from "dayjs";
 import {getRangetxt } from '../methods/get';
 import {luckysheetupdateCell} from '../controllers/updateCell';
@@ -6971,22 +6970,6 @@ export function getCurrentSheetIndex(){
  */
 export function showSelectionCopy (range) {
     selectionCopyShow(range)
-}
-
-/**
- * 显示区域选择框
- * @param {*} txt 默认展示选区字符串
- * @param {*} confirmCallback 确认选中选区的回调 
- */
-export function showSelectionRangeDialog(txt, confirmCallback){
-    const _this = customCtrl
-    _this.init(confirmCallback)
-    _this.rangeDialog(txt);
-
-    let range = _this.getRangeByTxt(txt);
-    _this.selectRange = getRangeDetailInfoArr(range);
-    
-    selectionCopyShow(_this.selectRange);
 }
 
 /**

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -1,5 +1,5 @@
 import Store from "../store";
-import { replaceHtml, getObjType, chatatABC, luckysheetactiveCell } from "../utils/util";
+import { replaceHtml, getObjType, chatatABC, luckysheetactiveCell, getRangeDetailInfoArr, getRangeDetailInfo } from "../utils/util";
 import { getSheetIndex, getluckysheet_select_save, getluckysheetfile } from "../methods/get";
 import locale from "../locale/locale";
 import method from './method';
@@ -31,13 +31,14 @@ import luckysheetsizeauto from '../controllers/resize';
 import sheetmanage from '../controllers/sheetmanage';
 import conditionformat from '../controllers/conditionformat';
 import { luckysheet_searcharray } from "../controllers/sheetSearch";
-import { selectHightlightShow, selectIsOverlap } from '../controllers/select';
-import { sheetHTML, luckysheetdefaultstyle } from '../controllers/constant';
+import { selectHightlightShow, selectIsOverlap, selectionCopyShow } from '../controllers/select';
+import { sheetHTML, luckysheetdefaultstyle, modelHTML } from '../controllers/constant';
 import { createFilterOptions } from '../controllers/filter';
 import controlHistory from '../controllers/controlHistory';
 import { zoomRefreshView, zoomNumberDomBind } from '../controllers/zoom';
 import dataVerificationCtrl from "../controllers/dataVerificationCtrl";
 import imageCtrl from '../controllers/imageCtrl';
+import customCtrl from '../controllers/customCtrl';
 import dayjs from "dayjs";
 import {getRangetxt } from '../methods/get';
 import {luckysheetupdateCell} from '../controllers/updateCell';
@@ -6789,6 +6790,15 @@ export function getRangeByTxt(txt){
     };
 }
 
+/**
+ * 根据范围字符串转换为range数组
+ * @param {String} txt 范围字符串
+ */
+export function getRangesByTxt(txt){
+    const range = conditionformat.getRangeByTxt(txt);
+    return range;
+}
+
 
 /**
  * 根据范围数组转换为范围字符串
@@ -6949,4 +6959,90 @@ export function openSearchDialog(source = 1){
     luckysheetSearchReplace.createDialog(source);
     luckysheetSearchReplace.init();
     $("#luckysheet-search-replace #searchInput input").focus();
+}
+
+export function getCurrentSheetIndex(){
+    return Store.currentSheetIndex
+}
+
+/**
+ * 展示选区
+ * @param {Array | Object | String} range 选区范围
+ */
+export function showSelectionCopy (range) {
+    selectionCopyShow(range)
+}
+
+/**
+ * 显示区域选择框
+ * @param {*} txt 默认展示选区字符串
+ * @param {*} confirmCallback 确认选中选区的回调 
+ */
+export function showSelectionRangeDialog(txt, confirmCallback){
+    const _this = customCtrl
+    _this.init(confirmCallback)
+    _this.rangeDialog(txt);
+
+    let range = _this.getRangeByTxt(txt);
+    _this.selectRange = getRangeDetailInfoArr(range);
+    
+    selectionCopyShow(_this.selectRange);
+}
+
+/**
+ * 检查某一单元格是否在指定区域内
+ * @param {Number} r 单元格所在行
+ * @param {Number} c 单元格所在列
+ * @param {Array} specifiedRange 指定区域 
+ */
+export function checkCellWithinSpecifiedRange(r, c, specifiedRange) {
+    let within = false
+    if (!specifiedRange || specifiedRange.length === 0) {
+        return false
+    }
+    for(let item of specifiedRange){
+        let r1 = item.row[0], r2 = item.row[1];
+        let c1 = item.column[0], c2 = item.column[1];
+
+        if(r>=r1 && r<=r2 && c>=c1 && c<=c2){
+            within = true;
+            break;
+        }
+    }
+    return within
+}
+
+/**
+ * 检查range是否在指定区域内
+ * @param {Array} range 需要检查的区域
+ * @param {Array} specifiedRange 指定区域 
+ */
+export function checkRangeWithinSpecifiedRange(range = [], specifiedRange = []) {
+    if (!specifiedRange || specifiedRange.length === 0) {
+        return false
+    }
+    if (!range || range.length === 0) {
+        return false
+    }
+
+    for(let item of range){
+        let r1 = item.row[0], r2 = item.row[1];
+        let c1 = item.column[0], c2 = item.column[1];
+
+        for(let r=r1;r<=r2;r++){
+            for(let c=c1;c<=c2;c++){
+                const within = checkCellWithinSpecifiedRange(r, c , specifiedRange);
+                if(!within){
+                    return false;
+                }
+            }
+        }
+    }
+    return true
+
+}
+
+export {
+    getRangeDetailInfoArr,
+    getRangeDetailInfo
 }

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -5929,13 +5929,14 @@ export function getAllChartsBase64(cb) {
             chartMap[item.index] = {}
             item.chart.forEach((chartInfo) => {
                 const chartDom = document.querySelector(`#${chartInfo.chart_id}`);
-                const chartInstance = echarts.getInstanceByDom(chartDom);
-                chartInstance.resize({width:chartInfo.width,height: chartInfo.height,animation: {
-                    duration: 0
-                }})
+                if (chartDom) {
+                    const chartInstance = echarts.getInstanceByDom(chartDom);
+                    chartInstance.resize({width:chartInfo.width,height: chartInfo.height,animation: {
+                        duration: 0
+                    }})
 
-                chartMap[item.index][chartInfo.chart_id] = chartInstance
-                
+                    chartMap[item.index][chartInfo.chart_id] = chartInstance
+                }
             });
 
         }

--- a/src/global/formula.js
+++ b/src/global/formula.js
@@ -5980,7 +5980,8 @@ const luckysheetformula = {
         }
 
         if (!_this.testFunction(txt, fp) || fp == "") {
-            tooltip.info("", locale_formulaMore.execfunctionError);
+            const file = Store.luckysheetfile[getSheetIndex(index)];
+            tooltip.info("", `${locale_formulaMore.execfunctionError}: ${file.name}>${chatatABC(c)}${r + 1}>${txt}`);
             return [false, _this.error.n, txt];
         }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -887,6 +887,49 @@ function camel2split(camel) {
     });
 }
 
+/**
+ * 根据range（只包含row column坐标） 转换为range的详细内容（除坐标 还有宽高 偏移量等）
+ * @param {Object} range 由getRangeByTxt方法返回{column, row}
+ */
+function getRangeDetailInfo(range) {
+    let r1 = range.row[0], r2 = range.row[1];
+    let c1 = range.column[0], c2 = range.column[1];
+    let row = Store.visibledatarow[r2], 
+        row_pre = r1 - 1 == -1 ? 0 : Store.visibledatarow[r1 - 1];
+    let col = Store.visibledatacolumn[c2], 
+        col_pre = c1 - 1 == -1 ? 0 : Store.visibledatacolumn[c1 - 1];
+
+    return { 
+        "left": col_pre, 
+        "width": col - col_pre - 1, 
+        "top": row_pre, 
+        "height": row - row_pre - 1, 
+        "left_move": col_pre, 
+        "width_move": col - col_pre - 1, 
+        "top_move": row_pre, 
+        "height_move": row - row_pre - 1, 
+        "row": [r1, r2], 
+        "column": [c1, c2], 
+        "row_focus": r1, 
+        "column_focus": c1 
+    }
+}
+
+/**
+ * 根据range数组，转换为range的详细内容数组
+ * @param {Array} rangeArr 由getRangesByTxt方法返回[{column, row}]
+ */
+function getRangeDetailInfoArr(rangeArr) {
+    const result = []
+    if(rangeArr.length > 0){
+        for(let s = 0; s < rangeArr.length; s++){
+            const detail = getRangeDetailInfo(rangeArr[s])
+            result.push(detail)
+        }
+    }
+    return result
+}
+
 export {
     isJsonString,
     common_extend,
@@ -917,4 +960,6 @@ export {
     createProxy,
     arrayRemoveItem,
     camel2split,
+    getRangeDetailInfo,
+    getRangeDetailInfoArr,
 };


### PR DESCRIPTION
新增：
1、优化公式错误时，输出所在sheet、坐标、及公式内容
2、设置保护区域后，当光标移动至在不允许输入区域内，禁止工具栏操作（合并单元格、边框、字体等等）

修复：
1、[不允许编辑时可以插入链接](https://github.com/dream-num/Luckysheet/commit/8bc7f886b0637848c8977d71b0425972f5b5662d)
2、[fix: 空值报错](https://github.com/dream-num/Luckysheet/commit/8a304cb755cf5fd98c84d483fb44e0f3ae9c9bed)