### PR TITLE
fix: 解决merge对应的行丢失时导致报错问题

### DIFF
--- a/src/controllers/sheetmanage.js
+++ b/src/controllers/sheetmanage.js
@@ -1192,6 +1192,11 @@ const sheetmanage = {
             let r = parseInt(x.substr(0, x.indexOf("_")));
             let c = parseInt(x.substr(x.indexOf("_") + 1));
             let mcInfo = mergeConfig[x];
+
+            if (data[r] == void 0) {
+                continue
+            }
+            
             if (data[r][c] == null) {
                 data[r][c] = {};
             }


### PR DESCRIPTION
问题复现步骤：

  1. 选择1-3行进行合并
  2. 删除第一行的row数据（json数据二次清洗需要去除当前行）
    此时再次进入，控制台报错

（原因是，合并单元格时，找不到该行数据，所以做一个容错处理）