### PR TITLE
fix: 解决嵌入luckysheet时，点击外部保存，单元格编辑内容未更新保存问题

### DIFF
--- a/src/controllers/handler.js
+++ b/src/controllers/handler.js
@@ -278,6 +278,13 @@ export default function luckysheetHandler() {
         menuButton.inputMenuButtonFocus(e.target);
     });
 
+    // 点击视图外部任意处，退出编辑模式
+    $("#luckysheet-rich-text-editor").on('blur', function(e){
+        if(e.relatedTarget) return
+        formula.updatecell(Store.luckysheetCellUpdate[0], Store.luckysheetCellUpdate[1]);
+        luckysheetMoveHighlightCell("down", 0, "rangeOfSelect");
+    })
+
     //表格mousedown
     $("#luckysheet-cell-main, #luckysheetTableContent")
         .mousedown(function(event) {


### PR DESCRIPTION
问题复现步骤：

1. 将luckysheet嵌入继承到别的平台页面
2. 外置保存按钮
3. 编辑单元格后直接点击外置保存按钮
4. 此时单元格未更新保存当前修改值
（因此，给input加个blur失焦事件，判断是点击的视图外，则保存当前更新内容，并退出编辑模式）