### PR TITLE
fix(src/css/luckysheet-core.css): 格式刷模式开启后，鼠标应该调整为格式刷图标

### DIFF
--- a/src/css/luckysheet-core.css
+++ b/src/css/luckysheet-core.css
@@ -5089,7 +5089,7 @@ fieldset[disabled] .btn-danger.focus {
 }
 
 .luckysheetPaintCursor {
-    cursor: url(paint_24px.ico), auto;
+    cursor: url(paint_24px.ico), auto !important;
 }
 
 /*        input {


### PR DESCRIPTION
fix #1388