### PR TITLE
destroy后不刷新页面重新create传入新的列数时会创建旧列数的表

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -55,7 +55,7 @@ luckysheet.create = function (setting) {
         }
     }
 
-    let extendsetting = common_extend(defaultSetting, setting);
+    let extendsetting = common_extend(structuredClone(defaultSetting), setting);
 
     let loadurl = extendsetting.loadUrl,
         menu = extendsetting.menu,


### PR DESCRIPTION
修复bug：destroy后不刷新页面重新create时，即使传入新的column字段，表格的大小也还是第一次createe时设定的值，原因在于create时Store从defaultSettings中读取了对象，而后续又经由Store对该对象进行了修改，导致对该对象的修改直接修改到了defaultSettings里面（毕竟defaultSettings不是一个扁平的对象），而destroy时并没有把defaultSettings还原，只还原了Store等其它对象。做为defaultSettings，应该是只读的，所以本pr在合并defaultSettings时先将其深度克隆一遍以防止其被修改，就可以防止第二次create时用到上一次的数据了。