### PR TITLE
handle case when localforage.getItem throws an error

### DIFF
--- a/src/controllers/sheetmanage.js
+++ b/src/controllers/sheetmanage.js
@@ -1069,6 +1069,10 @@ const sheetmanage = {
                     server.clearcachelocaldata(function() {
                         ini();
                     });
+                })
+                .catch(function(e) {
+                    ini();
+                    console.log("缓存操作失败");
                 });
             } catch (e) {
                 ini();


### PR DESCRIPTION
this handles the case when `localforage.getItem` throws an async error. without this fix, luckysheet gets stuck in the loading state when an error occurs.