### PR TITLE
fix: 复制时，如果从Excel复制的单元格过长，会导致复制到页面出现换行的清空

### DIFF
--- a/src/controllers/handler.js
+++ b/src/controllers/handler.js
@@ -6096,12 +6096,12 @@ export default function luckysheetHandler() {
                             $tr.find(cellElements).each(function() {
                                 let $td = $(this);
                                 let cell = {};
-                                let txt = $td.text();
+                                let txt = $td?.[0].innerText;
                                 if ($.trim(txt).length == 0) {
                                     cell.v = null;
                                     cell.m = "";
                                 } else {
-                                    let mask = genarate($td.text());
+                                    let mask = genarate(txt);
                                     cell.v = mask[2];
                                     cell.ct = mask[1];
                                     cell.m = mask[0];


### PR DESCRIPTION
Q1. 复制时，如果单元格数据过长，导致的换行问题
A1. 因为JQ text函数问题，修改为原生引用innerText
    影响文件 src\controllers\handler.js (6099、6104行)
    
    
可通过示例数据 复制到 表格复现。复制后表格中显示内容为
"iPhone
  Xs Max-1213213213321131322133213-121321321321"
而非
"iPhone Xs Max-1213213213321131322133213-121321321321"

[示例数据.xlsx](https://github.com/dream-num/Luckysheet/files/12617680/default.xlsx)






















































































