### PR TITLE
fix: 修复create之后，直接调用insertRow，导致公式计算报错

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -36,6 +36,32 @@ import { hideloading, showloading } from "./global/loading.js";
 import { luckysheetextendData } from "./global/extend.js";
 import { initChat } from './demoData/chat.js'
 
+import {
+  luckysheet_compareWith,
+  luckysheet_getarraydata,
+  luckysheet_getcelldata, 
+  luckysheet_parseData,
+  luckysheet_getValue,
+  luckysheet_indirect_check,
+  luckysheet_indirect_check_return,
+  luckysheet_offset_check,
+  luckysheet_calcADPMM,
+  luckysheet_getSpecialReference,
+} from "./function/func";
+
+if (!window.luckysheet_compareWith) {
+  window.luckysheet_compareWith = luckysheet_compareWith;
+  window.luckysheet_getarraydata = luckysheet_getarraydata;
+  window.luckysheet_getcelldata = luckysheet_getcelldata;
+  window.luckysheet_parseData = luckysheet_parseData;
+  window.luckysheet_getValue = luckysheet_getValue;
+  window.luckysheet_indirect_check = luckysheet_indirect_check;
+  window.luckysheet_indirect_check_return = luckysheet_indirect_check_return;
+  window.luckysheet_offset_check = luckysheet_offset_check;
+  window.luckysheet_calcADPMM = luckysheet_calcADPMM;
+  window.luckysheet_getSpecialReference = luckysheet_getSpecialReference;
+}
+
 let luckysheet = {};
 
 // mount api

--- a/src/global/formula.js
+++ b/src/global/formula.js
@@ -5264,18 +5264,18 @@ const luckysheetformula = {
             data = Store.flowdata;
         }
 
-        if (!window.luckysheet_compareWith) {
-            window.luckysheet_compareWith = luckysheet_compareWith;
-            window.luckysheet_getarraydata = luckysheet_getarraydata;
-            window.luckysheet_getcelldata = luckysheet_getcelldata;
-            window.luckysheet_parseData = luckysheet_parseData;
-            window.luckysheet_getValue = luckysheet_getValue;
-            window.luckysheet_indirect_check = luckysheet_indirect_check;
-            window.luckysheet_indirect_check_return = luckysheet_indirect_check_return;
-            window.luckysheet_offset_check = luckysheet_offset_check;
-            window.luckysheet_calcADPMM = luckysheet_calcADPMM;
-            window.luckysheet_getSpecialReference = luckysheet_getSpecialReference;
-        }
+        // if (!window.luckysheet_compareWith) {
+        //     window.luckysheet_compareWith = luckysheet_compareWith;
+        //     window.luckysheet_getarraydata = luckysheet_getarraydata;
+        //     window.luckysheet_getcelldata = luckysheet_getcelldata;
+        //     window.luckysheet_parseData = luckysheet_parseData;
+        //     window.luckysheet_getValue = luckysheet_getValue;
+        //     window.luckysheet_indirect_check = luckysheet_indirect_check;
+        //     window.luckysheet_indirect_check_return = luckysheet_indirect_check_return;
+        //     window.luckysheet_offset_check = luckysheet_offset_check;
+        //     window.luckysheet_calcADPMM = luckysheet_calcADPMM;
+        //     window.luckysheet_getSpecialReference = luckysheet_getSpecialReference;
+        // }
 
         if (_this.execFunctionGlobalData == null) {
             _this.execFunctionGlobalData = {};


### PR DESCRIPTION
在create之后，直接调用insertRow方法，如果当前工作表有公式，会自动计算，但是insertRow逻辑没有经过formula.execFunctionGroup，导致window上没有相关变量，所以公式计算 变量未定义 的错误