### PR TITLE
cellFormat: cells unlocked by default

### DIFF
--- a/src/controllers/cellFormat.js
+++ b/src/controllers/cellFormat.js
@@ -162,7 +162,7 @@ export function openCellFormatModel(){
         recycleSeletion(
             function(cell){
                 // let cell = data[r][c];
-                if(cell==null || cell.lo==null || cell.lo==1){
+                if (cell!=null && cell.lo!=null && cell.lo==1){
                     locked = true;
                     lockedCount++;
                 }


### PR DESCRIPTION
I want to lock only headers (row 0) with fixed titles,
Rest of sheet should be editable when I activate protection